### PR TITLE
Разделяет шаг цикла и начало анимации

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,12 +33,11 @@
 
     function render() {
         window.scrollBy(0, -scrollStep);
-        scrollingNow = true;
         scroll();
     }
 
     function scroll() {
-        if (window.scrollY) {
+        if (window.scrollY && scrollingNow) {
             animationLoop = setTimeout(renderRequest, 1000 / defaultSpeed);
         }
     }
@@ -48,11 +47,16 @@
         scrollingNow = false;
     }
 
+    function start() {
+        scrollingNow = true;
+        scroll();
+    }
+
     function toggle() {
         if (scrollingNow) {
             pause();
         } else {
-            scroll();
+            start();
         }
     }
 


### PR DESCRIPTION
Редко возникает ситуация, когда кадр анимации начинается раньше, чем срабатывает пробел (на экстремально больших скоростях) и тогда приходится нажимать пробел по нескольку раз, потому что кадр отменяет действие нажатого пробела. Этот патч это исправляет.